### PR TITLE
add tests for controller

### DIFF
--- a/Controller/src/controller/controller_test.go
+++ b/Controller/src/controller/controller_test.go
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package controller
+
+import (
+	"io/ioutil"
+	"log"
+	"testing"
+
+	"github.com/FirebaseExtended/fcm-external-prober/Probe/src/utils"
+)
+
+func TestGetPossibleZones(t *testing.T) {
+	testStrings := []string{"REGION-a\nREGION-b\nREGION2-a\nREGION2-B",
+		"INFORMATION\nMIN_CPU\nOTHER_INFORMATION", "INFORMATION"}
+	maker = utils.NewFakeCommandMaker(testStrings, []bool{false, false, false}, false)
+	cfg, err := ioutil.ReadFile("testConfig.txt")
+	if err != nil {
+		t.Log("TestGetPossibleZones: unable to parse configuration file")
+		t.FailNow()
+	}
+	ctrl := NewController(string(cfg), maker)
+
+	ctrl.getPossibleZones()
+
+	if len(ctrl.vms) != 1 {
+		t.Logf("TestGetPossibleZones: incorrect number of resulting zones: actual: %d, expeted: %d", len(ctrl.vms), 1)
+		t.FailNow()
+	}
+	for _, v := range ctrl.config.Probes.Probe {
+		if ctrl.vms[v.GetRegion()] != nil {
+			t.Logf("TestGetPossibleZones: incorrect value in resulting vm object")
+			t.Fail()
+		}
+	}
+}
+
+func TestStartVMs(t *testing.T) {
+	testStrings := []string{"REGION-a\nREGION-b\nREGION2-a\nREGION2-b\nREGION3-a",
+		"INFORMATION\nMIN_CPU\nOTHER_INFORMATION", "MIN_CPU", "INFORMATION", "", ""}
+	maker = utils.NewFakeCommandMaker(testStrings, make([]bool, 6), false)
+	cfg, err := ioutil.ReadFile("testConfig.txt")
+	if err != nil {
+		t.Log("TestStartVMs: unable to parse configuration file")
+		t.FailNow()
+	}
+	ctrl := NewController(string(cfg), maker)
+
+	ctrl.StartVMs()
+
+	for _, p := range ctrl.config.Probes.Probe {
+		if !ctrl.vms[p.GetRegion() + "-a"].active {
+			t.Log("TestStartVMs: zonal VM for which a probe exists is not active")
+			t.Fail()
+		}
+		ctrl.vms[p.GetRegion() + "-a"].active = false
+	}
+
+	for _, v := range ctrl.vms {
+		if v.active {
+			t.Log("TestStartVMs: zonal VM for which a probe does not exist is active")
+		}
+	}
+}
+
+func TestCommands(t *testing.T) {
+	maker := new(utils.CmdMaker)
+	str, err := maker.Command("gcloud", "compute", "ssh", "us-east4-a", "--zone", "us-east4-a", "--command", "echo hello").Output()
+	if err != nil {
+		log.Print("failed to ssh")
+		t.Fail()
+	}
+	log.Print(string(str))
+}

--- a/Controller/src/controller/regionFinder.go
+++ b/Controller/src/controller/regionFinder.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"errors"
-	"os/exec"
 	"regexp"
 	"strings"
 )
@@ -29,13 +28,13 @@ func getCompatZones(reqs []string) ([]string, error) {
 		return nil, err
 	}
 	var ret []string
-	for i := 0; i < len(r); i++ {
-		str, err := listZoneInfo(r[i])
+	for _, s := range r {
+		str, err := listZoneInfo(s)
 		if err != nil {
 			return nil, err
 		}
 		if meetsRequirements(str, reqs) {
-			ret = append(ret, str)
+			ret = append(ret, s)
 		}
 	}
 	if len(ret) == 0 {
@@ -51,12 +50,12 @@ func findZones() ([]string, error) {
 	}
 	// Match all strings that represent zone names that end in -a, i.e. us-east1-a
 	// For now, assume that only one zone is needed per region
-	reg := regexp.MustCompile(".*-a")
+	reg := regexp.MustCompile(".*-a\\b")
 	return reg.FindAllString(str, -1), nil
 }
 
 func listZoneInfo(zone string) (string, error) {
-	out, err := exec.Command("gcloud", "compute", "regions", "describe", zone).Output()
+	out, err := maker.Command("gcloud", "compute", "zones", "describe", zone).Output()
 	if err != nil {
 		return "", err
 	}
@@ -73,7 +72,7 @@ func meetsRequirements(inf string, req []string) bool {
 }
 
 func listZones() (string, error) {
-	out, err := exec.Command("gcloud", "compute", "zones", "list").Output()
+	out, err := maker.Command("gcloud", "compute", "zones", "list").Output()
 	if err != nil {
 		return "", err
 	}

--- a/Controller/src/controller/regionFinder_test.go
+++ b/Controller/src/controller/regionFinder_test.go
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/FirebaseExtended/fcm-external-prober/Probe/src/utils"
+)
+
+func TestGetCompatZones(t *testing.T) {
+	testStrings := []string{"us-east1-a\nus-east1-b\nus-east2-abc\nus-east3-a\tus-east3\tUP",
+		"Item1\nItem2\nItem3\nItem4", "Item1\nItem2\nItem3"}
+	reqs := []string{"Item1", "Item4"}
+	expectedOut := []string{"us-east1-a"}
+	maker = utils.NewFakeCommandMaker(testStrings, []bool{false, false, false}, false)
+
+	res, err := getCompatZones(reqs)
+
+	if err != nil {
+		t.Logf("TestGetCompatZones: returned error on valid input")
+		t.Fail()
+	}
+	if len(res) != len(expectedOut) {
+		t.Logf("TestGetCompatZones: incorrect output length: actual: %d, expected: %d", len(res), len(expectedOut))
+		t.FailNow()
+	}
+	for i, s := range expectedOut {
+		if res[i] != s {
+			t.Logf("TestGetCompatZones: incorrect output value: actual: %s, expected: %s", res[i], s)
+			t.Fail()
+		}
+	}
+}
+
+func TestFindZones(t *testing.T) {
+	testString := "us-east1-a\nus-east1-b\nus-east2-abc\nus-east3-a\tus-east3\tUP"
+	expectedOut := []string{"us-east1-a", "us-east3-a"}
+	maker = utils.NewFakeCommandMaker([]string{testString}, []bool{false}, false)
+	res, err := findZones()
+	if err != nil {
+		t.Log("TestFindZones: returned error on valid input")
+		t.Fail()
+	}
+	if len(res) != len(expectedOut) {
+		t.Logf("TestFindZones: incorrect output length: actual: %d, expected: %d", len(res), len(expectedOut))
+		t.FailNow()
+	}
+	for i, s := range expectedOut {
+		if s != res[i] {
+			t.Logf("TestFindZones: incorrect output value: actual: %s, expected: %s", res[i], s)
+			t.Fail()
+		}
+	}
+}
+
+func TestMeetsRequirements(t *testing.T) {
+	testString := "Item1\nItem2\nItem3\nItem4"
+	testReqs := []string{"Item1", "Item2", "Item4"}
+	res := meetsRequirements(testString, testReqs)
+	if !res {
+		t.Log("TestMeetsRequirements: returned false on true input")
+		t.Fail()
+	}
+}
+
+func TestMeetsRequirementsNegative(t *testing.T) {
+	testString := "Item1\nItem2\nItem3\nItem4"
+	testReqs := []string{"Item1", "Item4", "Item5"}
+	res := meetsRequirements(testString, testReqs)
+	if res {
+		t.Log("TestMeetsRequirementsNegative: returned true on false input")
+		t.Fail()
+	}
+}

--- a/Controller/src/controller/testConfig.txt
+++ b/Controller/src/controller/testConfig.txt
@@ -1,0 +1,22 @@
+probes: <
+  probe: <
+    region: "REGION"
+    type: UNSPECIFIED
+    send_number: 0
+    send_interval: 0
+    receive_timeout: 0
+  >
+  probe: <
+    region: "REGION2"
+    type: UNSPECIFIED
+    send_number: 0
+    send_interval: 0
+    receive_timeout: 0
+  >
+>
+account: <
+  service_account: "SERVICE_ACCOUNT"
+  gcp_project: "PROJECT"
+>
+min_cpu: "MIN_CPU"
+disk_image_name: "DISK_IMAGE_NAME"

--- a/Controller/src/main.go
+++ b/Controller/src/main.go
@@ -19,17 +19,19 @@ package main
 import (
 	"controller"
 	"flag"
+	"github.com/FirebaseExtended/fcm-external-prober/Probe/src/utils"
 	"io/ioutil"
 	"log"
 )
 
 func main() {
-	cf := flag.String("config", "config.txt", "text file in which a protobuf with config information is located")
+	cf := flag.String("config", "src/config.txt", "text file in which a protobuf with config information is located")
+	flag.Parse()
 	c, err := ioutil.ReadFile(*cf)
 	if err != nil {
 		log.Fatalf("Main: could not read from specified config file: %s", err.Error())
 	}
-	ctrl := controller.NewController(string(c))
+	ctrl := controller.NewController(string(c), new(utils.CmdMaker))
 	ctrl.StartVMs()
 	ctrl.StartProbes()
 }


### PR DESCRIPTION
## Change Summary

Added tests for the functionality of `controller.go` and `regionFinder.go`
Commands are mocked in the same way as in tests for the probe
`regionalVM.go` is untested, as its functions are only wrappers for calling command line functions. If more-granular testing is desired, `FakeCommandMaker` could be augmented to verify expected command input during testing, but this is low-priority at the moment in favor of completing the MVP.

