### PR TITLE
Add Controller gRPC

### DIFF
--- a/Controller/controller.proto
+++ b/Controller/controller.proto
@@ -32,6 +32,12 @@ message AccountInfo {
     optional string gcp_project = 2;
 }
 
+message PingConfig {
+    optional int32 interval = 1;
+    optional int32 timeout = 2;
+    optional int32 retries = 3;
+}
+
 message Heartbeat {
     optional bool stop = 1;
     optional string source = 2;
@@ -44,7 +50,7 @@ message RegisterRequest {
 message RegisterResponse {
     optional ProbeConfigs probes = 1;
     optional AccountInfo account = 2;
-    optional int32 ping_interval = 3;
+    optional PingConfig ping_config = 3;
 }
 
 service ProbeCommunicator {

--- a/Controller/controller.proto
+++ b/Controller/controller.proto
@@ -3,10 +3,9 @@ syntax = "proto2";
 message ControllerConfig {
     optional ProbeConfigs probes = 1;
     optional AccountInfo account = 2;
-    optional string min_cpu = 3;
-    optional string disk_image_name = 4;
-    optional int32 vm_timeout_minutes = 5;
-    optional int32 vm_ping_interval = 6;
+    optional PingConfig ping_config = 3;
+    optional string min_cpu = 4;
+    optional string disk_image_name = 5;
 }
 
 enum ProbeType {

--- a/Controller/controller.proto
+++ b/Controller/controller.proto
@@ -6,6 +6,8 @@ message ControllerConfig {
     optional PingConfig ping_config = 3;
     optional string min_cpu = 4;
     optional string disk_image_name = 5;
+    optional string host_ip = 6;
+    optional int32 port = 7;
 }
 
 enum ProbeType {

--- a/Controller/controller.proto
+++ b/Controller/controller.proto
@@ -5,6 +5,8 @@ message ControllerConfig {
     optional AccountInfo account = 2;
     optional string min_cpu = 3;
     optional string disk_image_name = 4;
+    optional int32 vm_timeout_minutes = 5;
+    optional int32 vm_ping_interval = 6;
 }
 
 enum ProbeType {
@@ -28,4 +30,24 @@ message ProbeConfig {
 message AccountInfo {
     optional string service_account = 1;
     optional string gcp_project = 2;
+}
+
+message Heartbeat {
+    optional bool stop = 1;
+    optional string source = 2;
+}
+
+message RegisterRequest {
+    optional string source = 1;
+}
+
+message RegisterResponse {
+    optional ProbeConfigs probes = 1;
+    optional AccountInfo account = 2;
+    optional int32 ping_interval = 3;
+}
+
+service ProbeCommunicator {
+    rpc Register(RegisterRequest) returns (RegisterResponse) {}
+    rpc Ping(Heartbeat) returns (Heartbeat) {}
 }

--- a/Controller/src/controller/controller.go
+++ b/Controller/src/controller/controller.go
@@ -23,65 +23,73 @@ package controller
 import (
 	"log"
 
-	"github.com/FirebaseExtended/fcm-external-prober/Probe/src/utils"
 	"github.com/golang/protobuf/proto"
 )
 
-var maker utils.CommandMaker
+var (
+	maker          utils.CommandMaker
+	vms            map[string]*regionalVM
+	stoppedVMs     int32
+	stoppedVMsLock sync.Mutex
+	running        bool
+	config         *ControllerConfig
+)
 
-type Controller struct {
-	config *ControllerConfig
-	vms    map[string]*regionalVM
-}
+type Controller struct{}
 
 // Create a new controller with a provided configuration
-func NewController(cfg string, mk utils.CommandMaker) *Controller {
-	maker = mk
-	ret := &Controller{new(ControllerConfig), make(map[string]*regionalVM)}
-
-	err := proto.UnmarshalText(cfg, ret.config)
-	if err != nil {
-		log.Fatalf("Controller: invalid configuration: %s", err.Error())
-	}
-	return ret
+func NewController(cfg controller.ControllerConfig, cmd utils.CommandMaker) *Controller {
+	config = cfg
+	maker = cmd
+	return &Controller{}
 }
 
-func (ctrl *Controller) getPossibleZones() {
-	zones, err := getCompatZones([]string{ctrl.config.GetMinCpu()})
+// Start all VMs in regions in which the required hardware is available, and for which there are probes specified
+func (ctrl *Controller) Control() {
+	err := initServer()
+	if err != nil {
+		log.Fatalf("Controller: unable to start rpc server, %v", err)
+	}
+
+	getPossibleZones()
+
+	// Assign all probe configurations to their designated regions
+	for _, p := range ctrl.config.Probes.Probe {
+		vm, ok := vms[p.GetRegion()+"-a"]
+		if !ok {
+			log.Printf("Controller: zone %s in region %s does not meet minimum requirements or does not exist", p.GetRegion()+"-a", p.GetRegion())
+			continue
+		}
+		vm.probes = append(vm.probes, p)
+	}
+
+	// Start VMs in regions to which probes are designated, remove those that contain no probes
+	for _, v := range vms {
+		if len(vm.probes) == 0 {
+			delete(vms, v)
+			continue
+		}
+		err := vm.startVM()
+		if err != nil {
+			log.Printf("Controller: regional VM could not be started in zone %s", vm.zone)
+		}
+	}
+	monitorProbes()
+}
+
+func getPossibleZones() {
+	z, err := getCompatZones([]string{config.GetMinCpu()})
 	if err != nil {
 		//TODO(langenbahn): Log this when logging is implemented
 		log.Fatalf("Controller: unable to generate list of VM zones")
 	}
 	for _, n := range zones {
 		// For now, the probe name is the same as the zone name. This will change if multiple VMs are required in a zone
-		ctrl.vms[n] = newRegionalVM(n, n, ctrl.config.GetMinCpu(), ctrl.config.GetDiskImageName())
+		vms[n] = newRegionalVM(n, n)
+		vms[n].setState(inactive)
 	}
 }
 
-// Start all VMs in regions in which the required hardware is available, and for which there are probes specified
-func (ctrl *Controller) StartVMs() {
-	ctrl.getPossibleZones()
-	for _, p := range ctrl.config.Probes.Probe {
-		vm, ok := ctrl.vms[p.GetRegion()+"-a"]
-		if !ok {
-			log.Printf("Controller: zone %s in region %s does not meet minimum requirements or does not exist", p.GetRegion()+"-a", p.GetRegion())
-			continue
-		}
-		if !vm.active {
-			err := vm.startVM(ctrl.config.GetMinCpu(), ctrl.config.GetDiskImageName(), ctrl.config.GetAccount().GetServiceAccount())
-			if err != nil {
-				log.Printf("Controller: regional VM could not be started in zone %s", vm.zone)
-			}
-		}
-		vm.probes = append(vm.probes, p)
-	}
-}
-
-// Start probing logic in all active VMs
-func (ctrl *Controller) StartProbes() {
-	for _, vm := range ctrl.vms {
-		if vm.active {
-			vm.startProbes(ctrl.config.GetAccount())
-		}
-	}
+func (ctrl *Controller) monitorProbes() {
+	checkVMs(config.RegionalVMTimeout)
 }

--- a/Controller/src/controller/controller.go
+++ b/Controller/src/controller/controller.go
@@ -96,11 +96,5 @@ func getPossibleZones() {
 }
 
 func monitorProbes() {
-	go thisisatestfunction()
 	checkVMs(time.Duration(config.PingConfig.GetTimeout()) * time.Minute)
-}
-
-func thisisatestfunction() {
-	time.Sleep(3 * time.Minute)
-	stopping = true;
 }

--- a/Controller/src/controller/regionFinder.go
+++ b/Controller/src/controller/regionFinder.go
@@ -54,6 +54,14 @@ func findZones() ([]string, error) {
 	return reg.FindAllString(str, -1), nil
 }
 
+func listZones() (string, error) {
+	out, err := maker.Command("gcloud", "compute", "zones", "list").Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
 func listZoneInfo(zone string) (string, error) {
 	out, err := maker.Command("gcloud", "compute", "zones", "describe", zone).Output()
 	if err != nil {
@@ -69,12 +77,4 @@ func meetsRequirements(inf string, req []string) bool {
 		}
 	}
 	return true
-}
-
-func listZones() (string, error) {
-	out, err := maker.Command("gcloud", "compute", "zones", "list").Output()
-	if err != nil {
-		return "", err
-	}
-	return string(out), nil
 }

--- a/Controller/src/controller/regionalVM.go
+++ b/Controller/src/controller/regionalVM.go
@@ -46,21 +46,23 @@ func newRegionalVM(name string, zone string) *regionalVM {
 func (vm *regionalVM) startVM() error {
 
 	//TODO(langenbahn): Edit this command to include startup script
-	err := maker.Command("gcloud", "compute", "instances", "create", vm.name, "--zone", vm.zone,
+	/*err := maker.Command("gcloud", "compute", "instances", "create", vm.name, "--zone", vm.zone,
 		"--quiet", "--min-cpu-platform", config.GetMinCpu(), "--image", config.GetDiskImageName(),
 		"--service-account", config.GetAccount().GetServiceAccount()).Run()
 	if err != nil {
 		return err
-	}
+	}*/
+	log.Print("Starting VM")
 	vm.setState(starting)
 	return nil
 }
 
 func (vm *regionalVM) stopVM() {
-	err := maker.Command("gcloud", "compute", "instances", "delete", vm.name, "--zone", vm.zone, "--quiet").Run()
+	/*err := maker.Command("gcloud", "compute", "instances", "delete", vm.name, "--zone", vm.zone, "--quiet").Run()
 	if err != nil {
 		log.Printf("stopVM: unable to stop VM %s in zone %s: %v", vm.name, vm.zone, err)
-	}
+	}*/
+	log.Print("Stopping VM")
 }
 
 func (vm *regionalVM) restartVM() {

--- a/Controller/src/controller/regionalVM.go
+++ b/Controller/src/controller/regionalVM.go
@@ -86,8 +86,8 @@ func (vm *regionalVM) updatePingTime() {
 
 func (vm *regionalVM) setState(s vmState) {
 	vm.stateLock.Lock()
+	defer vm.stateLock.Unlock()
 	if vm.state == stopped {
-		vm.stateLock.Unlock()
 		return
 	} else if s == stopped {
 		stoppedVMsLock.Lock()
@@ -95,5 +95,4 @@ func (vm *regionalVM) setState(s vmState) {
 		stoppedVMsLock.Unlock()
 	}
 	vm.state = s
-	vm.stateLock.Unlock()
 }

--- a/Controller/src/controller/rpc.go
+++ b/Controller/src/controller/rpc.go
@@ -111,7 +111,7 @@ func (cs *CommunicatorServer) Ping(ctx context.Context, in *Heartbeat) (*Heartbe
 func checkVMs(max time.Duration) {
 	for stoppedVMs < len(vms) {
 		for _, vm := range vms {
-			if checkVM(vm) {
+			if isTimedOut(vm, max) {
 				vm.restartVM()
 			}
 		}
@@ -119,8 +119,8 @@ func checkVMs(max time.Duration) {
 	}
 }
 
-func isTimedOut(vm *regionalVM, max *time.Duration) bool {
+func isTimedOut(vm *regionalVM, max time.Duration) bool {
 	vm.stateLock.Lock()
 	defer vm.stateLock.Unlock()
-	return (vm.state == starting || vm.state == idle || vm.state == probing) && clock.Now().After(vm.lastPing.Add(*max))
+	return (vm.state == starting || vm.state == idle || vm.state == probing) && clock.Now().After(vm.lastPing.Add(max))
 }

--- a/Controller/src/controller/rpc.go
+++ b/Controller/src/controller/rpc.go
@@ -52,7 +52,7 @@ func makeCert() error {
 type CommunicatorServer struct{}
 
 // Provides regional VMs with information about which probes to run
-func (pc *CommunicatorServer) Register(ctx context.Context, in *controller.RegisterRequest) (*controller.RegisterResponse, error) {
+func (cs *CommunicatorServer) Register(ctx context.Context, in *controller.RegisterRequest) (*controller.RegisterResponse, error) {
 	vm, ok := vms[in.Source]
 	if !ok {
 		//TODO(langenbahn): log this error
@@ -65,7 +65,7 @@ func (pc *CommunicatorServer) Register(ctx context.Context, in *controller.Regis
 }
 
 // Processes incoming information from probes
-func (pc *CommunicatorServer) Ping(ctx context.Context, in *controller.Heartbeat) (*controller.Heartbeat, error) {
+func (cs *CommunicatorServer) Ping(ctx context.Context, in *controller.Heartbeat) (*controller.Heartbeat, error) {
 	if in.GetStop() {
 		vms[in.GetSource()].restartVM()
 	} else {

--- a/Controller/src/controller/rpc.go
+++ b/Controller/src/controller/rpc.go
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package controller
+
+var cert []byte
+
+func initServer() {
+	err := makeCert()
+	if err != nil {
+		return err
+	}
+	tls, err := credentials.NewServerTLSFromFile("cert.pem", "key.pem")
+	if err != nil {
+		return err
+	}
+	srv := grpc.NewServer(grpc.Creds(tls))
+	lis, err := net.Listen("tcp", "crdhost.c.gifted-cooler-279818.internal:50001")
+	if err != nil {
+		return err
+	}
+	controller.RegisterProbeCommunicatorServer(srv, new(CommunicatorServer))
+}
+
+func makeCert() error {
+	err := maker.Command("openssl", "req", "-x509", "-newkey", "rsa:4096", "-keyout", "key.pem", "-out", "cert.pem", "-days", "365", "-nodes", "-subj", "'/CN=crdhost.c.gifted-cooler-279818'").Run()
+	if err != nil {
+		return err
+	}
+	// Read public certificate so that it can be included in regional vm metadata
+	cert, err := ioutil.ReadFile("cert.pem")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Handles communication between controller and regional VMs
+type CommunicatorServer struct{}
+
+// Provides regional VMs with information about which probes to run
+func (pc *CommunicatorServer) Register(ctx context.Context, in *controller.RegisterRequest) (*controller.RegisterResponse, error) {
+	vm, ok := vms[in.Source]
+	if !ok {
+		//TODO(langenbahn): log this error
+		log.Print("Register: given source does not correspond to an existing VM")
+		return &controller.RegisterResponse{}
+	}
+	vm.setState(idle)
+	vm.updatePingTime()
+	return &controller.RegisterResponse{probes: &ProbeConfigs{Probe: vm.probes}, account: config.GetAccount(), pingInterval: config.GetVmPingInterval()}, nil
+}
+
+// Processes incoming information from probes
+func (pc *CommunicatorServer) Ping(ctx context.Context, in *controller.Heartbeat) (*controller.Heartbeat, error) {
+	if in.GetStop() {
+		vms[in.GetSource()].restartVM()
+	} else {
+		vms[in.GetSource()].setState(probing)
+	}
+	vms[in.Source].updatePingTime()
+	in.Source = "Controller"
+	in.Stop = running
+	return in, nil
+}
+
+func checkVMs(max time.Duration, wg *sync.WaitGroup) {
+	for stoppedVMs < len(vms) {
+		for _, v := range vms {
+			vm.stateLock.Lock()
+			if (vm.state == starting || vm.state == idle || vm.state == probing) && time.Now().After(v.lastPing.Add(max)) {
+				vm.stateLock.Unlock()
+				v.restartVM()
+			} else {
+				vm.stateLock.Unlock()
+			}
+		}
+		//Have a channel here that this can block on?
+		time.Sleep(1 * time.Minute)
+	}
+	wg.Done()
+}

--- a/Controller/src/main.go
+++ b/Controller/src/main.go
@@ -17,25 +17,27 @@
 package main
 
 import (
-	"controller"
 	"flag"
-	"github.com/FirebaseExtended/fcm-external-prober/Probe/src/utils"
 	"io/ioutil"
 	"log"
+
+	"github.com/FirebaseExtended/fcm-external-prober/Controller/src/controller"
+	"github.com/FirebaseExtended/fcm-external-prober/Probe/src/utils"
+	"github.com/golang/protobuf/proto"
 )
 
 func main() {
-	cf := flag.String("config", "src/config.txt", "text file in which a protobuf with config information is located")
+	cf := flag.String("config", "config.txt", "text file in which a protobuf with config information is located")
 	flag.Parse()
 	c, err := ioutil.ReadFile(*cf)
 	if err != nil {
 		log.Fatalf("Main: could not read from specified config file: %s", err.Error())
 	}
-	cfg = new(ControllerConfig)
-	err := proto.UnmarshalText(c, cfg)
+	cfg := new(controller.ControllerConfig)
+	err = proto.UnmarshalText(string(c), cfg)
 	if err != nil {
 		log.Fatalf("Main: invalid configuration: %s", err.Error())
 	}
-	ctrl := controller.NewController(cfg, new(utils.CmdMaker))
+	ctrl := controller.NewController(cfg, new(utils.CmdMaker), new(utils.ProbeClock))
 	ctrl.Control()
 }

--- a/Controller/src/main.go
+++ b/Controller/src/main.go
@@ -31,7 +31,11 @@ func main() {
 	if err != nil {
 		log.Fatalf("Main: could not read from specified config file: %s", err.Error())
 	}
-	ctrl := controller.NewController(string(c), new(utils.CmdMaker))
-	ctrl.StartVMs()
-	ctrl.StartProbes()
+	cfg = new(ControllerConfig)
+	err := proto.UnmarshalText(c, cfg)
+	if err != nil {
+		log.Fatalf("Main: invalid configuration: %s", err.Error())
+	}
+	ctrl := controller.NewController(cfg, new(utils.CmdMaker))
+	ctrl.Control()
 }


### PR DESCRIPTION
## Change Summary
Added RPC declarations to `controller.proto`
Added implementation of `ProbeCommunicatorServer` to controller in `rpc.go`
Added concurrent timeout checker to handle the case in which a probe becomes decoupled from the controller
General refactoring to improve readability and reduce the complexity of control flow

Updated test cases and adding RPC logic to the probe will both come in separate PRs.
