### PR TITLE
add cloud logging support

### DIFF
--- a/Probe/src/main.go
+++ b/Probe/src/main.go
@@ -24,6 +24,6 @@ import (
 func main() {
 	m := new(utils.CmdMaker)
 	c := new(utils.ProbeClock)
-	l := probe.NewCloudLogger()
+	l := new(probe.CloudLogger)
 	probe.Control(m, c, l)
 }

--- a/Probe/src/probe/fakeLogger.go
+++ b/Probe/src/probe/fakeLogger.go
@@ -16,13 +16,28 @@
 
 package probe
 
+import "fmt"
+
 // Collects calls to LogProbe for later analysis
 type fakeLogger struct {
 	testLogs []testLog
+	errLogs  []string
 }
 
 func (t *fakeLogger) LogProbe(sp *sentProbe, st string, lat int) {
 	t.testLogs = append(t.testLogs, testLog{sp.sendTime.Format(timeLogFormat), st, lat})
+}
+
+func (t *fakeLogger) LogFatal(desc string) {
+	t.LogError("fatal: " + desc)
+}
+
+func (t *fakeLogger) LogError(desc string) {
+	t.errLogs = append(t.errLogs, desc)
+}
+
+func (t *fakeLogger) LogFatalf(desc string, args ...interface{}) {
+	t.errLogs = append(t.errLogs, fmt.Sprintf(desc, args...))
 }
 
 type testLog struct {

--- a/Probe/src/probe/localController.go
+++ b/Probe/src/probe/localController.go
@@ -44,7 +44,7 @@ func Control(mk utils.CommandMaker, clk utils.Timer, lg Logger) {
 
 	err := initClient()
 	if err != nil {
-		log.Fatalf("Control: unable to initialize gRPC client")
+		logger.LogFatalf("Control: unable to initialize gRPC client:, %v", err)
 	}
 
 	defer destroyEnvironment()
@@ -52,7 +52,7 @@ func Control(mk utils.CommandMaker, clk utils.Timer, lg Logger) {
 	initEnvironment()
 	tok, err := getToken()
 	if err != nil {
-		log.Fatalf("Control: could not acquire device token, %s", err.Error())
+		logger.LogFatalf("Control: could not acquire device token: %v", err)
 	}
 	deviceToken = tok
 	ps := makeProbes()
@@ -75,22 +75,22 @@ func Control(mk utils.CommandMaker, clk utils.Timer, lg Logger) {
 func initEnvironment() {
 	err := startEmulator()
 	if err != nil {
-		log.Fatalf("probe: could not start emulator: %s", err.Error())
+		logger.LogFatalf("probe: could not start emulator: %v", err)
 	}
 	err = startApp()
 	if err != nil {
-		log.Fatalf("probe: could not install app: %s", err.Error())
+		logger.LogFatalf("probe: could not install app: %v", err)
 	}
 }
 
 func destroyEnvironment() {
 	err := uninstallApp()
 	if err != nil {
-		log.Printf("probe: unable to uninstall app: %s", err.Error())
+		log.Printf("probe: unable to uninstall app: %v", err)
 	}
 	err = killEmulator()
 	if err != nil {
-		log.Fatalf("probe: could not kill emulator: %s", err.Error())
+		logger.LogFatalf("probe: could not kill emulator: %v", err)
 	}
 }
 
@@ -132,6 +132,6 @@ func stopResolver(rwg *sync.WaitGroup) {
 }
 
 func deleteVM() {
-	log.Printf("delete VM")
+	//TODO(langenbahn) Remove this when not developing on a GCE VM
 	//maker.Command("gcloud", "compute", "instances", "delete", hostname, "--zone", hostname, "--quiet")
 }

--- a/Probe/src/probe/logger.go
+++ b/Probe/src/probe/logger.go
@@ -16,21 +16,79 @@
 
 package probe
 
-import "log"
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+)
 
+// Wrapper for logging
 type Logger interface {
 	LogProbe(sp *sentProbe, st string, lat int)
+	LogError(desc string)
+	LogFatal(desc string)
+	LogFatalf(desc string, args ...interface{})
 }
 
+// Logger that sends logs to cloud logger via gcloud
 type CloudLogger struct {
-	// TODO(langenbahn): Add fields when logging is implemented
 }
 
-func NewCloudLogger() *CloudLogger {
-	return new(CloudLogger)
+//TODO(langenbahn): add log/error destinations in config proto
+type probeLog struct {
+	sendTime  string
+	probeType string
+	latency   int
+	state     string
+	region    string
+	token     string
 }
 
+type errorLog struct {
+	desc   string
+	region string
+	token  string
+}
+
+// Log probe information to specified log
 func (c *CloudLogger) LogProbe(sp *sentProbe, st string, lat int) {
-	//TODO(langenbahn): Implement logging
-	log.Printf("time: %s status: %s latency: %d", sp.sendTime.Format(timeLogFormat), st, lat)
+	cl := &probeLog{sp.sendTime.Format(timeLogFormat), sp.probe.getTypeString(), lat, st,
+		sp.probe.config.GetRegion(), deviceToken}
+	l, err := json.Marshal(cl)
+	if err != nil {
+		c.LogError(fmt.Sprintf("Unable to log probe: unable to marshal JSON: %v", err))
+	}
+
+	err = maker.Command("gcloud", "logging", "write",
+		"--payload-type=json", "PROBELOG", string(l)).Run()
+	if err != nil {
+		c.LogError(fmt.Sprintf("Unable to log probe: unable to send to server: %v", err))
+	}
+}
+
+func (c *CloudLogger) LogFatal(desc string) {
+	c.LogError(fmt.Sprintf("fatal: %s", desc))
+	os.Exit(1)
+}
+
+func (c *CloudLogger) LogFatalf(desc string, args ...interface{}) {
+	c.LogError(fmt.Sprintf("fatal: "+desc, args...))
+	os.Exit(1)
+}
+
+// Log errors to specified log
+func (c *CloudLogger) LogError(desc string) {
+	//TODO(langenbahn) add any other useful information for errors
+	el := &errorLog{desc, probeConfigs.Probe[0].GetRegion(), deviceToken}
+	l, err := json.Marshal(el)
+	if err != nil {
+		log.Printf("Unable to log error: unable to marshal JSON: %v", err)
+	}
+
+	err = maker.Command("gcloud", "logging", "write",
+		"--payload-type=json", "ERRORLOG", string(l)).Run()
+	if err != nil {
+		log.Printf("Unable to log probe: unable to send to server: %v", err)
+	}
 }

--- a/Probe/src/probe/probe.go
+++ b/Probe/src/probe/probe.go
@@ -62,3 +62,14 @@ func (p *probe) probe(pwg *sync.WaitGroup) {
 	}
 	pwg.Done()
 }
+
+func (p *probe) getTypeString() string {
+	switch *p.config.Type {
+	case controller.ProbeType_UNSPECIFIED:
+		return "UNSPECIFIED"
+	case controller.ProbeType_TOPIC:
+		return "TOPIC"
+	default:
+		return "NONE"
+	}
+}

--- a/Probe/src/probe/probe.go
+++ b/Probe/src/probe/probe.go
@@ -62,14 +62,3 @@ func (p *probe) probe(pwg *sync.WaitGroup) {
 	}
 	pwg.Done()
 }
-
-func (p *probe) getTypeString() string {
-	switch *p.config.Type {
-	case controller.ProbeType_UNSPECIFIED:
-		return "UNSPECIFIED"
-	case controller.ProbeType_TOPIC:
-		return "TOPIC"
-	default:
-		return "NONE"
-	}
-}

--- a/Probe/src/probe/rpc.go
+++ b/Probe/src/probe/rpc.go
@@ -42,7 +42,6 @@ func getMetadata() {
 	// Configuration for
 }
 
-
 func initClient() error {
 	tls, err := credentials.NewClientTLSFromFile("cert.pem", "")
 	if err != nil {


### PR DESCRIPTION
## Change Summary

Add function that sends logs for both probes and errors to Cloud Logging via the `gcloud` cli.
Update `logger` interface and `fakeLogger` to include above functions
Change `log.Fatalf()` to log using new logging functions

Next steps:
add configuration that allows for the log location to be specified
add any additional useful information for errors
