### PR TITLE
add metadata to probe and controller

### DIFF
--- a/Controller/controller.proto
+++ b/Controller/controller.proto
@@ -2,18 +2,15 @@ syntax = "proto2";
 
 message ControllerConfig {
     optional ProbeConfigs probes = 1;
-    optional AccountInfo account = 2;
+    optional MetadataConfig metadata = 2;
     optional PingConfig ping_config = 3;
     optional string min_cpu = 4;
     optional string disk_image_name = 5;
-    optional string host_ip = 6;
-    optional int32 port = 7;
 }
 
 enum ProbeType {
     UNSPECIFIED = 0;
-    ONCE_PER_INSTALL = 1;
-    TOPIC = 2;
+    TOPIC = 1;
 }
 
 message ProbeConfigs {
@@ -23,9 +20,8 @@ message ProbeConfigs {
 message ProbeConfig {
     optional string region = 1;
     optional ProbeType type = 2;
-    optional int32 send_number = 3;
-    optional int32 send_interval = 4;
-    optional int32 receive_timeout = 5;
+    optional int32 send_interval = 3;
+    optional int32 receive_timeout = 4;
 }
 
 message AccountInfo {
@@ -38,6 +34,17 @@ message PingConfig {
     optional int32 timeout = 2;
     optional int32 retries = 3;
     optional int32 retry_interval = 4;
+}
+
+message MetadataConfig {
+    optional AccountInfo account = 1;
+    optional string host_ip = 2;
+    optional int32 port = 3;
+    optional string probe_log_destination = 4;
+    optional string error_log_destination = 5;
+    optional int32 register_timeout = 6;
+    optional int32 register_retries = 7;
+    optional bytes cert = 8;
 }
 
 message Heartbeat {

--- a/Controller/src/controller/controller.go
+++ b/Controller/src/controller/controller.go
@@ -55,6 +55,10 @@ func (ctrl *Controller) InitServer() {
 	if err != nil {
 		log.Fatalf("Controller: unable to start rpc server, %v", err)
 	}
+	err = addMetadata()
+	if err != nil {
+		log.Fatalf("Controller: unable to add project metadata %v", err)
+	}
 }
 
 // Start all VMs in regions in which the required hardware is available, and for which there are probes specified

--- a/Controller/src/controller/controller_test.go
+++ b/Controller/src/controller/controller_test.go
@@ -34,7 +34,8 @@ func TestGetPossibleZones(t *testing.T) {
 	cfg, err := getTestConfig("testConfig.txt")
 	config = cfg
 	if err != nil {
-		t.Log("TestGetPossibleZones: unable to parse test configuration file")
+		t.Logf("TestGetPossibleZones: unable to parse test configuration file: %v", err)
+		t.FailNow()
 	}
 
 	getPossibleZones()
@@ -58,7 +59,8 @@ func TestController(t *testing.T) {
 	timer := utils.NewFakeClock([]time.Time{time.Unix(0, 0), time.Unix(1, 0), time.Unix(1, 0), time.Unix(1, 0), time.Unix(2, 0)}, false)
 	cfg, err := getTestConfig("testConfig.txt")
 	if err != nil {
-		t.Log("TestGetPossibleZones: unable to parse test configuration file")
+		t.Logf("TestGetPossibleZones: unable to parse test configuration file: %v", err)
+		t.FailNow()
 	}
 	ctrl := NewController(cfg, maker, timer)
 	stopping = true

--- a/Controller/src/controller/regionalVM.go
+++ b/Controller/src/controller/regionalVM.go
@@ -49,7 +49,7 @@ func (vm *regionalVM) startVM() error {
 	//TODO(langenbahn): Edit this command to include startup script
 	err := maker.Command("gcloud", "compute", "instances", "create", vm.name, "--zone", vm.zone,
 		"--quiet", "--min-cpu-platform", config.GetMinCpu(), "--image", config.GetDiskImageName(),
-		"--service-account", config.GetAccount().GetServiceAccount()).Run()
+		"--service-account", config.Metadata.Account.GetServiceAccount()).Run()
 	if err != nil {
 		return err
 	}

--- a/Controller/src/controller/rpc.go
+++ b/Controller/src/controller/rpc.go
@@ -44,7 +44,7 @@ func initServer() error {
 		return err
 	}
 	srv := grpc.NewServer(grpc.Creds(tls))
-	lis, err := net.Listen("tcp", fmt.Sprintf("%s:%d", config.Metadata.GetHostIp(), config.Metadata.GetPort()))
+	lis, err := net.Listen("tcp", fmt.Sprintf("%s:%d", config.GetMetadata().GetHostIp(), config.GetMetadata().GetPort()))
 	if err != nil {
 		return err
 	}
@@ -76,7 +76,7 @@ func makeCert() error {
 }
 
 func addMetadata() error {
-	md := proto.MarshalTextString(config.Metadata)
+	md := proto.MarshalTextString(config.GetMetadata())
 	err := maker.Command("gcloud", "compute", "project-info", "add-metadata", "--metadata=probeData="+md).Run()
 	if err != nil {
 		return err
@@ -100,7 +100,7 @@ func (cs *CommunicatorServer) Register(ctx context.Context, in *RegisterRequest)
 	vm.updatePingTime()
 	return &RegisterResponse{
 		Probes:     &ProbeConfigs{Probe: vm.probes},
-		Account:    config.Metadata.GetAccount(),
+		Account:    config.GetMetadata().GetAccount(),
 		PingConfig: config.GetPingConfig()}, nil
 }
 
@@ -125,7 +125,7 @@ func checkVMs(max time.Duration) {
 				vm.restartVM()
 			}
 		}
-		time.Sleep(time.Duration(config.PingConfig.GetInterval()) * time.Minute)
+		time.Sleep(time.Duration(config.GetPingConfig().GetInterval()) * time.Minute)
 	}
 }
 

--- a/Controller/src/controller/rpc_test.go
+++ b/Controller/src/controller/rpc_test.go
@@ -60,10 +60,6 @@ func TestRegisterExpected(t *testing.T) {
 		t.Log("TestRegisterExpected: Incorrect number of probes returned from Register")
 		t.Fail()
 	}
-	if res.GetAccount() != config.GetAccount() {
-		t.Log("TestRegisterExpected: Incorrect account information returned from Register")
-		t.Fail()
-	}
 	if res.GetPingConfig() != config.GetPingConfig() {
 		t.Log("TestRegisterExpected: Incorrect ping configuration returned from Register")
 		t.Fail()

--- a/Controller/src/controller/testConfig.txt
+++ b/Controller/src/controller/testConfig.txt
@@ -12,9 +12,18 @@ probes: <
     receive_timeout: 0
   >
 >
-account: <
-  service_account: "SERVICE_ACCOUNT"
-  gcp_project: "PROJECT"
+metadata: <
+    account: <
+      service_account: "SERVICE_ACCOUNT"
+      gcp_project: "PROJECT"
+    >
+    host_ip: "localhost"
+    port: 10000
+    probe_log_destination: "PROBE_LOG"
+    error_log_destination: "ERROR_LOG"
+    register_timeout: 0
+    register_retries: 0
+    cert: "00"
 >
 ping_config: <
   interval: 0
@@ -23,5 +32,3 @@ ping_config: <
 >
 min_cpu: "MIN_CPU"
 disk_image_name: "DISK_IMAGE_NAME"
-host_ip: "localhost"
-port: 10000

--- a/Controller/src/main.go
+++ b/Controller/src/main.go
@@ -39,5 +39,7 @@ func main() {
 		log.Fatalf("Main: invalid configuration: %s", err.Error())
 	}
 	ctrl := controller.NewController(cfg, new(utils.CmdMaker), new(utils.ProbeClock))
-	ctrl.Control()
+	ctrl.InitServer()
+	ctrl.InitProbes()
+	ctrl.MonitorProbes()
 }

--- a/Probe/src/probe/fcmHandler.go
+++ b/Probe/src/probe/fcmHandler.go
@@ -43,7 +43,7 @@ func (a *Auth) getToken() (string, error) {
 func (a *Auth) prepareAuth() error {
 	// GET request for authentication credentials for interacting with FCM and Cloud Logger
 	get, err := maker.Command("curl",
-		"http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/"+account.GetServiceAccount()+"/token",
+		"http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/"+metadata.GetAccount().GetServiceAccount()+"/token",
 		"-H", "Metadata-Flavor: Google").Output()
 	if err != nil {
 		return err
@@ -66,7 +66,7 @@ func (a *Auth) sendMessage(time string, ptype int) error {
 		return err
 	}
 	err = maker.Command("bash", "send", "-d", deviceToken, "-a", auth, "-t", time,
-		"-p", account.GetGcpProject(), "-y", fmt.Sprintf("%d", ptype)).Run()
+		"-p", metadata.GetAccount().GetGcpProject(), "-y", fmt.Sprintf("%d", ptype)).Run()
 	if err != nil {
 		return err
 	}

--- a/Probe/src/probe/logger.go
+++ b/Probe/src/probe/logger.go
@@ -62,7 +62,7 @@ func (c *CloudLogger) LogProbe(sp *sentProbe, st string, lat int) {
 	}
 
 	err = maker.Command("gcloud", "logging", "write",
-		"--payload-type=json", "PROBELOG", string(l)).Run()
+		"--payload-type=json", metadata.GetProbeLogDestination(), string(l)).Run()
 	if err != nil {
 		c.LogError(fmt.Sprintf("Unable to log probe: unable to send to server: %v", err))
 	}
@@ -91,7 +91,7 @@ func (c *CloudLogger) LogError(desc string) {
 	}
 
 	err = maker.Command("gcloud", "logging", "write",
-		"--payload-type=json", "ERRORLOG", string(l)).Run()
+		"--payload-type=json", metadata.GetErrorLogDestination(), string(l)).Run()
 	if err != nil {
 		log.Printf("Unable to log probe: unable to send to server: %v", err)
 	}

--- a/Probe/src/probe/probe.go
+++ b/Probe/src/probe/probe.go
@@ -62,15 +62,3 @@ func (p *probe) probe(pwg *sync.WaitGroup) {
 	}
 	pwg.Done()
 }
-
-func (p *probe) getTypeString() string {
-	// Will need to update this function if additional probe types are added
-	switch p.config.GetType() {
-	case controller.ProbeType_UNSPECIFIED:
-		return "default"
-	case controller.ProbeType_TOPIC:
-		return "topic"
-	default:
-		return ""
-	}
-}

--- a/Probe/src/probe/probe.go
+++ b/Probe/src/probe/probe.go
@@ -62,3 +62,15 @@ func (p *probe) probe(pwg *sync.WaitGroup) {
 	}
 	pwg.Done()
 }
+
+func (p *probe) getTypeString() string {
+	// Will need to update this function if additional probe types are added
+	switch p.config.GetType() {
+	case controller.ProbeType_UNSPECIFIED:
+		return "default"
+	case controller.ProbeType_TOPIC:
+		return "topic"
+	default:
+		return ""
+	}
+}

--- a/Probe/src/probe/probeResolver.go
+++ b/Probe/src/probe/probeResolver.go
@@ -113,7 +113,7 @@ func resolveProbe(sp *sentProbe) bool {
 	} else {
 		lat, err := calculateLatency(sp.sendTime, st)
 		if err != nil {
-			// Message received but Data is not present/readable
+			// Message received but data is not present/readable
 			logger.LogProbe(sp, "error", lat)
 		} else {
 			logger.LogProbe(sp, "resolved", lat)

--- a/Probe/src/probe/probeResolver.go
+++ b/Probe/src/probe/probeResolver.go
@@ -30,10 +30,9 @@ var (
 	resolveLock sync.Mutex
 	closeLock   sync.Mutex
 	closed      bool
-	unresolved  chan *sentProbe
+	// Use buffered channel so that resolving blocks on having no probes to resolve
+	unresolved chan *sentProbe
 )
-
-// Use buffered channel so that resolving blocks on having no probes to resolve
 
 type sentProbe struct {
 	sendTime time.Time
@@ -114,7 +113,7 @@ func resolveProbe(sp *sentProbe) bool {
 	} else {
 		lat, err := calculateLatency(sp.sendTime, st)
 		if err != nil {
-			// Message received but data is not present/readable
+			// Message received but Data is not present/readable
 			logger.LogProbe(sp, "error", lat)
 		} else {
 			logger.LogProbe(sp, "resolved", lat)

--- a/Probe/src/probe/rpc_test.go
+++ b/Probe/src/probe/rpc_test.go
@@ -21,6 +21,9 @@ import (
 	"testing"
 
 	"github.com/FirebaseExtended/fcm-external-prober/Controller/src/controller"
+	"github.com/FirebaseExtended/fcm-external-prober/Probe/src/utils"
+	"github.com/golang/protobuf/proto"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -62,6 +65,26 @@ func initVars(host string, retries int32) {
 	hostname = host
 	client = new(TestClient)
 	pingConfig = &controller.PingConfig{Retries: &retries}
+	metadata = &controller.MetadataConfig{RegisterRetries: &retries}
+}
+
+func TestGetMetadata(t *testing.T) {
+	ip := "TEST_IP"
+	testMeta := &controller.MetadataConfig{HostIp: &ip}
+	encodedMeta := proto.MarshalTextString(testMeta)
+	testString := "testItem.key:   probeData\n" +
+		"testItem.value: " + encodedMeta
+	maker = utils.NewFakeCommandMaker([]string{testString}, []bool{false}, false)
+
+	err := getMetadata()
+	if err != nil {
+		t.Logf("TestGetMetadata: error returned on valid input %v", err)
+		t.FailNow()
+	}
+	if metadata.GetHostIp() != "TEST_IP" {
+		t.Logf("TestGetMetadata: metadata unmarshalled incorrectly")
+		t.Fail()
+	}
 }
 
 func TestRegisterExpected(t *testing.T) {


### PR DESCRIPTION
## Change Summary

Controller Proto:
Added `MetadataConfig` message
Moved `AccountInfo` message into `MetadataConfig`
Removed `send_number` field from `ProbeConfig`

Controller:
Added wrapper for adding metadata to project info using `glcoud` cli
Updated references to `config.AccountInfo`
Improved error output in controller tests

Probe:
Added functionality to acquire metadata from project info and parse it appropriately
Added tests for above functionality
Updated references to `account`
Added information acquired from metadata where appropriate
Moved a comment in `probeResolver` to improve clarity

