### PR TITLE
Integration Test Bugfixes

### DIFF
--- a/Controller/controller.proto
+++ b/Controller/controller.proto
@@ -45,7 +45,7 @@ message MetadataConfig {
     optional string error_log_destination = 5;
     optional int32 register_timeout = 6;
     optional int32 register_retries = 7;
-    optional bytes cert = 8;
+    optional string cert = 8;
 }
 
 message Heartbeat {

--- a/Controller/controller.proto
+++ b/Controller/controller.proto
@@ -45,7 +45,8 @@ message MetadataConfig {
     optional string error_log_destination = 5;
     optional int32 register_timeout = 6;
     optional int32 register_retries = 7;
-    optional string cert = 8;
+    optional int32 register_retry_interval = 8;
+    optional string cert = 9;
 }
 
 message Heartbeat {

--- a/Controller/src/controller/controller.go
+++ b/Controller/src/controller/controller.go
@@ -30,7 +30,7 @@ import (
 var (
 	maker          utils.CommandMaker
 	clock          utils.Timer
-	logger		   Logger
+	logger         Logger
 	vms            map[string]*regionalVM
 	stoppedVMs     int
 	stoppedVMsLock sync.Mutex

--- a/Controller/src/controller/controller_test.go
+++ b/Controller/src/controller/controller_test.go
@@ -28,11 +28,10 @@ import (
 type fakeControllerLogger struct {
 }
 
-func (f *fakeControllerLogger) LogFatal(desc string){}
-func (f *fakeControllerLogger) LogFatalf(desc string, args ...interface{}){}
-func (f *fakeControllerLogger) LogError(desc string){}
-func (f *fakeControllerLogger) LogErrorf(desc string, args ...interface{}){}
-
+func (f *fakeControllerLogger) LogFatal(desc string)                       {}
+func (f *fakeControllerLogger) LogFatalf(desc string, args ...interface{}) {}
+func (f *fakeControllerLogger) LogError(desc string)                       {}
+func (f *fakeControllerLogger) LogErrorf(desc string, args ...interface{}) {}
 
 func TestGetPossibleZones(t *testing.T) {
 	testStrings := []string{"REGION-a\nREGION-b\nREGION2-a\nREGION2-B",

--- a/Controller/src/controller/logger.go
+++ b/Controller/src/controller/logger.go
@@ -22,6 +22,7 @@ import (
 	"os"
 )
 
+// Wrapper for controller error logging to Cloud Logger
 type Logger interface {
 	LogFatal(desc string)
 	LogFatalf(desc string, args ...interface{})
@@ -31,18 +32,22 @@ type Logger interface {
 
 // Logs controller-based errors
 type ControllerLogger struct {
+	Destination string // Location in Cloud Logger to which errors are logged
 }
 
+// Log error and terminate program
 func (c *ControllerLogger) LogFatal(desc string) {
 	c.LogError(fmt.Sprintf("fatal: %s", desc))
 	os.Exit(1)
 }
 
+// Log error with format and terminate program
 func (c *ControllerLogger) LogFatalf(desc string, args ...interface{}) {
 	c.LogError(fmt.Sprintf("fatal: "+desc, args...))
 	os.Exit(1)
 }
 
+// Log error to Cloud Logger
 func (c *ControllerLogger) LogError(desc string) {
 	err := maker.Command("gcloud", "logging", "write", config.GetControllerLogDestination(), desc).Run()
 	if err != nil {
@@ -50,6 +55,7 @@ func (c *ControllerLogger) LogError(desc string) {
 	}
 }
 
+// Log error with format
 func (c *ControllerLogger) LogErrorf(desc string, args ...interface{}) {
 	c.LogError(fmt.Sprintf(desc, args...))
 }

--- a/Controller/src/controller/regionalVM.go
+++ b/Controller/src/controller/regionalVM.go
@@ -48,7 +48,7 @@ func (vm *regionalVM) startVM() error {
 	//TODO(langenbahn): Edit this command to include startup script
 	err := maker.Command("gcloud", "compute", "instances", "create", vm.name, "--zone", vm.zone,
 		"--quiet", "--min-cpu-platform", config.GetMinCpu(), "--image", config.GetDiskImageName(),
-		"--service-account", config.Metadata.Account.GetServiceAccount()).Run()
+		"--service-account", config.GetMetadata().GetAccount().GetServiceAccount()).Run()
 	if err != nil {
 		return err
 	}

--- a/Controller/src/controller/rpc.go
+++ b/Controller/src/controller/rpc.go
@@ -70,7 +70,7 @@ func makeCert() error {
 	if err != nil {
 		return err
 	}
-	*config.Metadata.Cert = string(cert)
+	config.GetMetadata().Cert = proto.String(string(cert))
 	return nil
 }
 

--- a/Controller/src/controller/rpc.go
+++ b/Controller/src/controller/rpc.go
@@ -43,7 +43,7 @@ func initServer() error {
 		return err
 	}
 	srv := grpc.NewServer(grpc.Creds(tls))
-	lis, err := net.Listen("tcp", fmt.Sprintf("%s:%d", config.GetMetadata().GetHostIp(), config.GetMetadata().GetPort()))
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", config.GetMetadata().GetPort()))
 	if err != nil {
 		return err
 	}
@@ -70,13 +70,13 @@ func makeCert() error {
 	if err != nil {
 		return err
 	}
-	config.Metadata.Cert = cert
+	*config.Metadata.Cert = string(cert)
 	return nil
 }
 
 func addMetadata() error {
 	md := proto.MarshalTextString(config.GetMetadata())
-	err := maker.Command("gcloud", "compute", "project-info", "add-metadata", "--metadata=probeData="+md).Run()
+	err := maker.Command("gcloud", "compute", "project-info", "add-metadata", fmt.Sprintf("--metadata=probeData=%s", md)).Run()
 	if err != nil {
 		return err
 	}
@@ -120,6 +120,7 @@ func (cs *CommunicatorServer) Ping(ctx context.Context, in *Heartbeat) (*Heartbe
 func checkVMs(max time.Duration) {
 	for stoppedVMs < len(vms) {
 		for _, vm := range vms {
+
 			if isTimedOut(vm, max) {
 				vm.restartVM()
 			}

--- a/Controller/src/controller/testConfig.txt
+++ b/Controller/src/controller/testConfig.txt
@@ -23,6 +23,7 @@ metadata: <
     error_log_destination: "ERROR_LOG"
     register_timeout: 0
     register_retries: 0
+    register_retry_interval: 0
     cert: "00"
 >
 ping_config: <

--- a/Controller/src/main.go
+++ b/Controller/src/main.go
@@ -38,7 +38,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("Main: invalid configuration: %s", err.Error())
 	}
-	ctrl := controller.NewController(cfg, new(utils.CmdMaker), new(utils.ProbeClock), new(controller.ControllerLogger))
+	ctrl := controller.NewController(cfg, new(utils.CmdMaker), new(utils.ProbeClock),
+		&controller.ControllerLogger{cfg.GetControllerLogDestination()})
 	ctrl.InitServer()
 	ctrl.InitProbes()
 	ctrl.MonitorProbes()

--- a/Probe/src/probe/fakeLogger.go
+++ b/Probe/src/probe/fakeLogger.go
@@ -24,16 +24,24 @@ type fakeLogger struct {
 	errLogs  []string
 }
 
-func (t *fakeLogger) LogProbe(sp *sentProbe, st string, lat int) {
-	t.testLogs = append(t.testLogs, testLog{sp.sendTime.Format(timeLogFormat), st, lat})
-}
+func (t *fakeLogger) SetRegion(reg string) {}
+func (t *fakeLogger) SetError(dest string) {}
+func (t *fakeLogger) SetLog(dest string)   {}
 
-func (t *fakeLogger) LogFatal(desc string) {
-	t.LogError("fatal: " + desc)
+func (t *fakeLogger) LogProbe(sp *sentProbe, st string, lat int, tok string) {
+	t.testLogs = append(t.testLogs, testLog{sp.sendTime.Format(timeLogFormat), st, lat, tok})
 }
 
 func (t *fakeLogger) LogError(desc string) {
 	t.errLogs = append(t.errLogs, desc)
+}
+
+func (t *fakeLogger) LogErrorf(desc string, args ...interface{}) {
+	t.LogError(fmt.Sprintf(desc, args...))
+}
+
+func (t *fakeLogger) LogFatal(desc string) {
+	t.LogError("fatal: " + desc)
 }
 
 func (t *fakeLogger) LogFatalf(desc string, args ...interface{}) {
@@ -44,4 +52,5 @@ type testLog struct {
 	time    string
 	state   string
 	latency int
+	token   string
 }

--- a/Probe/src/probe/logger.go
+++ b/Probe/src/probe/logger.go
@@ -58,7 +58,6 @@ type probeLog struct {
 type errorLog struct {
 	Desc   string `json:"description"` // Error description
 	Region string `json:"region"`      // Region in which VM is located
-	Token  string `json:"token"`       // Device token (if applicable)
 }
 
 // Set the region in which VM is located
@@ -96,7 +95,7 @@ func (c *CloudLogger) LogProbe(sp *sentProbe, st string, lat int, tok string) {
 // Log errors to specified log
 func (c *CloudLogger) LogError(desc string) {
 	//TODO(langenbahn) add any other useful information for errors
-	el := &errorLog{desc, hostname, deviceToken}
+	el := &errorLog{desc, c.Region}
 	l, err := json.Marshal(el)
 	//TODO(langenbahn): in the case that an error message cannot be sent to the server,
 	//send through gRPC connection if available

--- a/Probe/src/probe/logger.go
+++ b/Probe/src/probe/logger.go
@@ -111,6 +111,7 @@ func (c *CloudLogger) LogError(desc string) {
 	}
 }
 
+// Log errors with format
 func (c *CloudLogger) LogErrorf(desc string, args ...interface{}) {
 	c.LogError(fmt.Sprintf(desc, args...))
 }

--- a/Probe/src/probe/logger.go
+++ b/Probe/src/probe/logger.go
@@ -37,18 +37,18 @@ type CloudLogger struct {
 
 //TODO(langenbahn): add log/error destinations in config proto
 type probeLog struct {
-	sendTime  string
-	probeType string
-	latency   int
-	state     string
-	region    string
-	token     string
+	SendTime  string `json:"sendTime"`
+	ProbeType string `json:"probeType"`
+	Latency   int    `json:"latency"`
+	State     string `json:"state"`
+	Region    string `json:"region"`
+	Token     string `json:"token"`
 }
 
 type errorLog struct {
-	desc   string
-	region string
-	token  string
+	Desc   string `json:"description"`
+	Region string `json:"region"`
+	Token  string `json:"token"`
 }
 
 // Log probe information to specified log
@@ -81,7 +81,7 @@ func (c *CloudLogger) LogFatalf(desc string, args ...interface{}) {
 // Log errors to specified log
 func (c *CloudLogger) LogError(desc string) {
 	//TODO(langenbahn) add any other useful information for errors
-	el := &errorLog{desc, probeConfigs.Probe[0].GetRegion(), deviceToken}
+	el := &errorLog{desc, hostname, deviceToken}
 	l, err := json.Marshal(el)
 	//TODO(langenbahn): in the case that an error message cannot be sent to the server,
 	//send through gRPC connection if available

--- a/Probe/src/probe/logger.go
+++ b/Probe/src/probe/logger.go
@@ -25,36 +25,61 @@ import (
 
 // Wrapper for logging
 type Logger interface {
-	LogProbe(sp *sentProbe, st string, lat int)
+	SetRegion(reg string)
+	SetError(dest string)
+	SetLog(dest string)
+	LogProbe(sp *sentProbe, st string, lat int, tok string)
 	LogError(desc string)
+	LogErrorf(desc string, args ...interface{})
 	LogFatal(desc string)
 	LogFatalf(desc string, args ...interface{})
 }
 
 // Logger that sends logs to cloud logger via gcloud
 type CloudLogger struct {
+	Region    string // Region in which VM is located
+	LogDest   string // Location in Cloud Logger where probes should be logged
+	ErrorDest string // Location in Cloud Logger where errors should be logged
 }
 
-//TODO(langenbahn): add log/error destinations in config proto
+func NewCloudLogger() *CloudLogger {
+	return &CloudLogger{"unspecified", "defaultLog", "defaultError"}
+}
+
 type probeLog struct {
-	SendTime  string `json:"sendTime"`
-	ProbeType string `json:"probeType"`
-	Latency   int    `json:"latency"`
-	State     string `json:"state"`
-	Region    string `json:"region"`
-	Token     string `json:"token"`
+	SendTime  string `json:"sendTime"`  // Send time of probe
+	ProbeType string `json:"probeType"` // Type of probe
+	Latency   int    `json:"latency"`   // Latency of probe
+	State     string `json:"state"`     // State of probe
+	Region    string `json:"region"`    // Region in which VM is located
+	Token     string `json:"token"`     // Device token of device on which the app is located
 }
 
 type errorLog struct {
-	Desc   string `json:"description"`
-	Region string `json:"region"`
-	Token  string `json:"token"`
+	Desc   string `json:"description"` // Error description
+	Region string `json:"region"`      // Region in which VM is located
+	Token  string `json:"token"`       // Device token (if applicable)
+}
+
+// Set the region in which VM is located
+func (c *CloudLogger) SetRegion(reg string) {
+	c.Region = reg
+}
+
+// Set error log location
+func (c *CloudLogger) SetError(dest string) {
+	c.ErrorDest = dest
+}
+
+// Set probe log location
+func (c *CloudLogger) SetLog(dest string) {
+	c.LogDest = dest
 }
 
 // Log probe information to specified log
-func (c *CloudLogger) LogProbe(sp *sentProbe, st string, lat int) {
+func (c *CloudLogger) LogProbe(sp *sentProbe, st string, lat int, tok string) {
 	cl := &probeLog{sp.sendTime.Format(timeLogFormat), sp.probe.config.Type.String(), lat, st,
-		sp.probe.config.GetRegion(), deviceToken}
+		c.Region, tok}
 	l, err := json.Marshal(cl)
 	if err != nil {
 		c.LogError(fmt.Sprintf("Unable to log probe: unable to marshal JSON: %v", err))
@@ -62,20 +87,10 @@ func (c *CloudLogger) LogProbe(sp *sentProbe, st string, lat int) {
 	}
 
 	err = maker.Command("gcloud", "logging", "write",
-		"--payload-type=json", metadata.GetProbeLogDestination(), string(l)).Run()
+		"--payload-type=json", c.LogDest, string(l)).Run()
 	if err != nil {
 		c.LogError(fmt.Sprintf("Unable to log probe: unable to send to server: %v", err))
 	}
-}
-
-func (c *CloudLogger) LogFatal(desc string) {
-	c.LogError(fmt.Sprintf("fatal: %s", desc))
-	os.Exit(1)
-}
-
-func (c *CloudLogger) LogFatalf(desc string, args ...interface{}) {
-	c.LogError(fmt.Sprintf("fatal: "+desc, args...))
-	os.Exit(1)
 }
 
 // Log errors to specified log
@@ -91,8 +106,24 @@ func (c *CloudLogger) LogError(desc string) {
 	}
 
 	err = maker.Command("gcloud", "logging", "write",
-		"--payload-type=json", metadata.GetErrorLogDestination(), string(l)).Run()
+		"--payload-type=json", c.ErrorDest, string(l)).Run()
 	if err != nil {
 		log.Printf("Unable to log error: unable to send to server: %v", err)
 	}
+}
+
+func (c *CloudLogger) LogErrorf(desc string, args ...interface{}) {
+	c.LogError(fmt.Sprintf(desc, args...))
+}
+
+// Log error and terminate
+func (c *CloudLogger) LogFatal(desc string) {
+	c.LogError(fmt.Sprintf("fatal: %s", desc))
+	os.Exit(1)
+}
+
+// Log error with format and terminate
+func (c *CloudLogger) LogFatalf(desc string, args ...interface{}) {
+	c.LogError(fmt.Sprintf("fatal: "+desc, args...))
+	os.Exit(1)
 }

--- a/Probe/src/probe/probeResolver.go
+++ b/Probe/src/probe/probeResolver.go
@@ -98,25 +98,25 @@ func resolveProbe(sp *sentProbe) bool {
 	}
 	st, err := getMessage(fmt.Sprintf("%d%s", sp.probe.config.GetType(), sp.sendTime.Format(timeFileFormat)))
 	if err != nil {
-		logger.LogProbe(sp, "error", -1)
+		logger.LogProbe(sp, "error", -1, deviceToken)
 		return true
 	}
 	if st == "nf" {
 		// Time out probe if it has been unresolved for too long
 		if clock.Now().After(sp.sendTime.Add(time.Duration(sp.probe.config.GetReceiveTimeout()) * time.Second)) {
-			logger.LogProbe(sp, "timeout", -1)
+			logger.LogProbe(sp, "timeout", -1, deviceToken)
 			return true
 		}
 		// File not found, so probe is still unresolved
-		logger.LogProbe(sp, "unresolved", -1)
+		logger.LogProbe(sp, "unresolved", -1, deviceToken)
 		return false
 	} else {
 		lat, err := calculateLatency(sp.sendTime, st)
 		if err != nil {
 			// Message received but data is not present/readable
-			logger.LogProbe(sp, "error", lat)
+			logger.LogProbe(sp, "error", lat, deviceToken)
 		} else {
-			logger.LogProbe(sp, "resolved", lat)
+			logger.LogProbe(sp, "resolved", lat, deviceToken)
 		}
 		return true
 	}

--- a/Probe/src/probe/probeResolver_test.go
+++ b/Probe/src/probe/probeResolver_test.go
@@ -30,6 +30,7 @@ func TestResolveProbes(t *testing.T) {
 	clock = utils.NewFakeClock([]time.Time{time.Unix(3, 0), time.Unix(100, 0)}, false)
 	fakeLogger := new(fakeLogger)
 	logger = fakeLogger
+	deviceToken = "TEST_TOKEN"
 
 	timeout := int32(2)
 	ptype := controller.ProbeType_UNSPECIFIED
@@ -53,6 +54,11 @@ func TestResolveProbes(t *testing.T) {
 	if len(logs) != 3 {
 		t.Logf("TestResolveProbes: not all probes resolved: %d", len(logs))
 		t.FailNow()
+	}
+	for i := 0; i < 3; i++ {
+		if logs[i].token != "TEST_TOKEN" {
+			t.Logf("TestResolveProbe: incorrect token logged: actual: %s, expected: %s", logs[i].token, deviceToken)
+		}
 	}
 	if logs[0].time != testProbes[0].sendTime.Format(timeLogFormat) || logs[0].state != "resolved" || logs[0].latency != 0 {
 		t.Logf("TestResolveProbe: probe 1 resolved incorrectly")

--- a/Probe/src/probe/rpc.go
+++ b/Probe/src/probe/rpc.go
@@ -54,7 +54,7 @@ func getProbeData(raw string) (*controller.MetadataConfig, error) {
 			// data will come in the form of: 'value: "DATA"'
 			probeData = strings.SplitN(items[i+1], ": ", 2)
 			// Remove trailing newline character from cert for unquoting
-			probeData[1] = probeData[1][:len(probeData[1]) - 1]
+			probeData[1] = strings.TrimSuffix(probeData[1], "\n")
 			var err error
 			probeData[1], err = strconv.Unquote(probeData[1])
 			if err != nil {
@@ -112,11 +112,6 @@ func initClient() error {
 	}
 	client = controller.NewProbeCommunicatorClient(conn)
 
-	hostname, err = getHostname()
-	if err != nil {
-		return err
-	}
-
 	cfg, err := register()
 	if err != nil {
 		return err
@@ -128,7 +123,7 @@ func initClient() error {
 
 func register() (*controller.RegisterResponse, error) {
 	req := &controller.RegisterRequest{Source: &hostname}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(metadata.GetRegisterTimeout()) * time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(metadata.GetRegisterTimeout())*time.Second)
 	defer cancel()
 
 	for i := 0; i < int(metadata.GetRegisterRetries()); i++ {

--- a/Probe/src/probe/rpc.go
+++ b/Probe/src/probe/rpc.go
@@ -19,6 +19,7 @@ package probe
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -104,7 +105,7 @@ func initClient() error {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(metadata.GetRegisterTimeout())*time.Second)
 	defer cancel()
-	conn, err := grpc.DialContext(ctx, "crdhost.c.gifted-cooler-279818.internal:50001",
+	conn, err := grpc.DialContext(ctx, fmt.Sprintf("%s:%d", metadata.GetHostIp(), metadata.GetPort()),
 		grpc.WithTransportCredentials(tls), grpc.WithBlock())
 	if err != nil {
 		return err
@@ -139,7 +140,7 @@ func register() (*controller.RegisterResponse, error) {
 		case codes.OK:
 			return cfg, nil
 		default:
-			time.Sleep(time.Duration(metadata.GetRegisterRetries()))
+			time.Sleep(time.Duration(metadata.GetRegisterRetryInterval()))
 		}
 	}
 	return nil, errors.New("register: maximum register retries exceeded")

--- a/Probe/src/probe/rpc_test.go
+++ b/Probe/src/probe/rpc_test.go
@@ -22,8 +22,6 @@ import (
 
 	"github.com/FirebaseExtended/fcm-external-prober/Controller/src/controller"
 	"github.com/FirebaseExtended/fcm-external-prober/Probe/src/utils"
-	"github.com/golang/protobuf/proto"
-
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -69,11 +67,9 @@ func initVars(host string, retries int32) {
 }
 
 func TestGetMetadata(t *testing.T) {
-	ip := "TEST_IP"
-	testMeta := &controller.MetadataConfig{HostIp: &ip}
-	encodedMeta := proto.MarshalTextString(testMeta)
-	testString := "testItem.key:   probeData\n" +
-		"testItem.value: " + encodedMeta
+	encodedMeta := "\"host_ip: \\\"TEST_IP\\\"\\ncert: \\\"TEST\\\\nCERT\\\"\"\n"
+	testString := "commonInstanceMetadata.items[0].key:   probeData\n" +
+		"commonInstanceMetadata.items[0].value: " + encodedMeta
 	maker = utils.NewFakeCommandMaker([]string{testString}, []bool{false}, false)
 
 	err := getMetadata()
@@ -81,7 +77,7 @@ func TestGetMetadata(t *testing.T) {
 		t.Logf("TestGetMetadata: error returned on valid input %v", err)
 		t.FailNow()
 	}
-	if metadata.GetHostIp() != "TEST_IP" {
+	if metadata.GetHostIp() != "TEST_IP" || metadata.GetCert() != "TEST\nCERT" {
 		t.Logf("TestGetMetadata: metadata unmarshalled incorrectly")
 		t.Fail()
 	}


### PR DESCRIPTION
## Change Summary

Goal of this PR: Run a manual integration test of the prober on one machine using the newly-added metadata feature, fixing bugs as they arise

Changes:
Fixed an issue where logs had no payload because the structs in `probe/logger.go` did not have json descriptors
Fixed an issue with metadata where data was not in the foreseen format (Had one additional layer of escaping of newline characters and escaped double quotes)
Added a field in the config proto to specify the retry interval for registering with the server
Refactored logger to function in a more-object-oriented way, addressing the problem of a possible segmentation fault if an error was logged before metadata was collected
Provided default logging destination values for use before hostname/metadata are collected
Updated test cases/`fakeLogger` in probe to address above changes in the `Logger` interface
Improved comment coverage of exported functions and struct members

