### PR TITLE
Add graceful stopping to controller

### DIFF
--- a/Controller/src/controller/controller.go
+++ b/Controller/src/controller/controller.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/signal"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/FirebaseExtended/fcm-external-prober/Probe/src/utils"
@@ -90,7 +91,7 @@ func (ctrl *Controller) InitProbes() {
 		}
 	}
 
-	go waitForInterrupt()
+	go waitForInterrupt(make(chan os.Signal))
 }
 
 func getPossibleZones() {
@@ -109,9 +110,8 @@ func (ctrl *Controller) MonitorProbes() {
 	checkVMs(time.Duration(config.PingConfig.GetTimeout()) * time.Minute)
 }
 
-func waitForInterrupt() {
-	intc := make(chan os.Signal)
-	signal.Notify(intc, os.Interrupt)
-	<- intc
+func waitForInterrupt(c chan os.Signal) {
+	signal.Notify(c, os.Interrupt, syscall.SIGINT)
+	<-c
 	stopping = true
 }

--- a/Controller/src/controller/controller.go
+++ b/Controller/src/controller/controller.go
@@ -21,6 +21,8 @@
 package controller
 
 import (
+	"os"
+	"os/signal"
 	"sync"
 	"time"
 
@@ -87,6 +89,8 @@ func (ctrl *Controller) InitProbes() {
 			logger.LogErrorf("Controller: regional VM could not be started in zone %s", v.zone)
 		}
 	}
+
+	go waitForInterrupt()
 }
 
 func getPossibleZones() {
@@ -103,4 +107,11 @@ func getPossibleZones() {
 
 func (ctrl *Controller) MonitorProbes() {
 	checkVMs(time.Duration(config.PingConfig.GetTimeout()) * time.Minute)
+}
+
+func waitForInterrupt() {
+	intc := make(chan os.Signal)
+	signal.Notify(intc, os.Interrupt)
+	<- intc
+	stopping = true
 }

--- a/Controller/src/controller/controller_test.go
+++ b/Controller/src/controller/controller_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -64,7 +65,7 @@ func TestController(t *testing.T) {
 	testStrings := []string{"REGION-a\nREGION-b\nREGION2-a\nREGION2-b\nREGION3-a",
 		"INFORMATION\nMIN_CPU\nOTHER_INFORMATION", "MIN_CPU", "INFORMATION", "", "", "", ""}
 	maker := utils.NewFakeCommandMaker(testStrings, make([]bool, 8), false)
-	times := []time.Time{time.Unix(0, 0), time.Unix(0,0), time.Unix(0, 0), time.Unix(1, 0), time.Unix(1, 0),
+	times := []time.Time{time.Unix(0, 0), time.Unix(0, 0), time.Unix(0, 0), time.Unix(1, 0), time.Unix(1, 0),
 		time.Unix(1, 0), time.Unix(2, 0)}
 	timer := utils.NewFakeClock(times, false)
 	cfg, err := getTestConfig("testConfig.txt")
@@ -84,6 +85,19 @@ func TestController(t *testing.T) {
 	}
 	if vms["REGION-a"].state != stopped || vms["REGION2-a"].state != stopped {
 		t.Logf("TestControl: Incorrect VM stopped")
+		t.Fail()
+	}
+}
+
+func TestWaitForInterrupt(t *testing.T) {
+	stopping = false
+	c := make(chan os.Signal)
+	go func() {
+		c <- os.Interrupt
+	}()
+	waitForInterrupt(c)
+	if !stopping {
+		t.Logf("TestWaitForInterrupt: stopping not set to false when process is interrupted")
 		t.Fail()
 	}
 }

--- a/Controller/src/controller/regionalVM.go
+++ b/Controller/src/controller/regionalVM.go
@@ -49,7 +49,7 @@ func (vm *regionalVM) startVM() error {
 		"--quiet", "--min-cpu-platform", config.GetMinCpu(),
 		"--service-account", config.GetMetadata().GetAccount().GetServiceAccount(),
 		"--image", config.GetImageName(), "--machine-type", "n1-standard-4", "--scopes", "cloud-platform",
-		"--metadata-from-file=startup-script=" + config.GetStartupScriptPath()).Run()
+		"--metadata-from-file=startup-script="+config.GetStartupScriptPath()).Run()
 	if err != nil {
 		return err
 	}

--- a/Controller/src/controller/regionalVM_test.go
+++ b/Controller/src/controller/regionalVM_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestRestartVM(t *testing.T) {
 	maker = utils.NewFakeCommandMaker(make([]string, 3), make([]bool, 3), false)
-	clock = utils.NewFakeClock([]time.Time{time.Unix(0, 0), time.Unix(0,0)}, false)
+	clock = utils.NewFakeClock([]time.Time{time.Unix(0, 0), time.Unix(0, 0)}, false)
 	stopping = false
 	vm := newRegionalVM("", "")
 

--- a/Controller/src/controller/rpc.go
+++ b/Controller/src/controller/rpc.go
@@ -120,7 +120,6 @@ func (cs *CommunicatorServer) Ping(ctx context.Context, in *Heartbeat) (*Heartbe
 func checkVMs(max time.Duration) {
 	for stoppedVMs < len(vms) {
 		for _, vm := range vms {
-
 			if isTimedOut(vm, max) {
 				vm.restartVM()
 			}

--- a/Probe/src/probe/appHandler.go
+++ b/Probe/src/probe/appHandler.go
@@ -135,6 +135,6 @@ func convertTime(t string) (*time.Time, error) {
 	if err != nil {
 		return nil, err
 	}
-	devt := time.Unix(sec, micro * 1000)
+	devt := time.Unix(sec, micro*1000)
 	return &devt, nil
 }

--- a/Probe/src/probe/localController.go
+++ b/Probe/src/probe/localController.go
@@ -62,7 +62,6 @@ func Control(mk utils.CommandMaker, clk utils.Timer, lg Logger) {
 	}
 	pwg := startProbes(ps)
 
-
 	err = communicate()
 	if err != nil {
 		logger.LogErrorf("Control: communication error, %v", err)

--- a/Probe/src/probe/probeResolver.go
+++ b/Probe/src/probe/probeResolver.go
@@ -31,7 +31,7 @@ var (
 	closeLock   sync.Mutex
 	closed      bool
 	// Use buffered channel so that resolving blocks on having no probes to resolve
-	unresolved chan *sentProbe
+	unresolved    chan *sentProbe
 	latencyOffset int
 )
 
@@ -134,5 +134,5 @@ func calculateLatency(st time.Time, rt string) (int, error) {
 	if err != nil {
 		return -1, err
 	}
-	return int(int64(t2) - t1) + latencyOffset, nil
+	return int(int64(t2)-t1) + latencyOffset, nil
 }

--- a/Probe/src/probe/probe_test.go
+++ b/Probe/src/probe/probe_test.go
@@ -43,7 +43,7 @@ func TestProbe(t *testing.T) {
 	addProbe(nil)
 
 	// Subtract command call and one clock call for initResolver
-	if testClock.TimesCalled() - 2 != 2*(testMaker.TimesCalled() - 1) {
+	if testClock.TimesCalled()-2 != 2*(testMaker.TimesCalled()-1) {
 		t.Log("TestProbe: clock and maker not accessed same number of times")
 		t.Fail()
 	}
@@ -56,7 +56,7 @@ func TestProbe(t *testing.T) {
 	}
 
 	// Subtract command call for initResolver
-	if i != testMaker.TimesCalled() - 1 {
+	if i != testMaker.TimesCalled()-1 {
 		t.Log("TestProbe: number of probes sent not equal to number of times sendMessage was called")
 		t.Fail()
 	}

--- a/Probe/src/probe/rpc.go
+++ b/Probe/src/probe/rpc.go
@@ -156,7 +156,7 @@ func communicate() error {
 
 func confirmStop() error {
 	// Probe is ceasing to run, so server response doesn't matter
-	_, err := pingServer(false)
+	_, err := pingServer(true)
 	if err != nil {
 		return errors.New("ConfirmStop: failed to communicate stopping to server")
 	}


### PR DESCRIPTION
## Change Summary

Added override for system interrupts to controller, which allows for a user to stop the controller in a way that allows probes to resolve any outstanding probes before all regional VMs are deleted.

Added test case to verify that override functions correctly
Fixed bug where `rpc.go/confirmStop()` was calling `rpc.go/pingServer()` with `false` instead of `true`, leading to the probe terminating, but not correctly communicating to the controller that it was terminating.
gofmt
